### PR TITLE
feat: Add draft of pull request template for all repos.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+# JIRA-1234: Example issue
+
+<!--
+- [ ] Fill in the issue number and title above
+-->
+
+## Context
+
+<!--
+- (especially if there are multiple PRs for the same story): What is (not) part of this PR?
+
+- Are there other PRs (in other repositories) connected to this one?
+-->
+
+## Contents
+
+<!--
+- What need does this PR fulfil?
+
+- How and why does it achieve that?
+  - (and what alternatives did you consider but not implement?)
+-->
+
+## Follow-ups (optional)
+
+<!--
+- any links to follow-up stories are appreciated! :)
+-->
+
+## Notes (optional)
+
+<!--
+- anything you want the reviewers to know
+- any obvious questions you expect and want to preempt?
+-->
+
+<!--
+Go through this checklist to make the review process extra smooth:
+
+- How can reviewers test your changes?
+- Do you have any updated documentation to share?
+- Is the PR title good? (it will become the commit message)
+  - currently a good-to-have, but not enforced: Following the https://www.conventionalcommits.org/en/v1.0.0/#summary syntax
+-->


### PR DESCRIPTION
# VAST-293: Create PR description template
## Context
This PR adds a PR description template to be used in all relevant AST GitHub repositories (at a later stage).

It does not actually be merged into `ast-common`, but as we do not have a GitHub repository template yet (see VAST-282), it needs to go somewhere until we do!

This PR shall serve as a place to gather RFC style feedback from the team.

## Contents
- only `.github/pull_request_template.md`

## Follow-ups (optional)
- VAST-282 to move the template somewhere central
- any potential follow-ups to VAST-282 to distribute the template to all relevant repositories.

## Notes (optional)
- A lot of the template is intentionally in comments so users can choose to leave the guidelines there while filling them out without them getting in the way in the rendered output 🙂
